### PR TITLE
Update utils-mappers.R

### DIFF
--- a/R/utils-mappers.R
+++ b/R/utils-mappers.R
@@ -168,10 +168,13 @@ bind_rows <- function(..., .id = NULL) {
 
   id_vals <- if (is.null(names(res))) 1:length(res) else names(res)
 
-  saf <- default.stringsAsFactors()
-  options(stringsAsFactors = FALSE)
-  on.exit(options(stringsAsFactors = saf))
-
+if( R.version$major<4 | ( R.version$major<=4 & R.version$minor=="0.0")) 
+    {
+      saf <- default.stringsAsFactors()
+      options(stringsAsFactors = FALSE)
+      on.exit(options(stringsAsFactors = saf))
+  }
+       
   idx <- 1
   do.call(
     rbind.data.frame,


### PR DESCRIPTION
Checks whether the R Version is 4.0.0 or older, otherwise dow not run default.StringAsFactors()